### PR TITLE
Error al iniciar sesión desde Mozilla Firefox

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', function () {
     window.location.href = 'index.html';
   }
 
-  document.getElementById('login').addEventListener('click', function () {
+  document.getElementById('login').addEventListener('click', async function () {
     ingresar();
   });
 });
@@ -66,9 +66,3 @@ function setUserIsLogged(isLogged) {
   // Doble negación para evita asignar algo que no sea Bool
   localStorage.setItem('userIsLogged', !!isLogged);
 }
-
-document.addEventListener('DOMContentLoaded', function () {
-  document.getElementById('login').addEventListener('click', async function () {
-    ingresar();
-  });
-});


### PR DESCRIPTION
Fixes #15

Resolver error de promesa no atrapada.
El error era causado por una duplicacion del codigo.
El codigo duplicado agregaba dos controladores casi identicos al btn.