### PR TITLE
Botón Modo Oscuro/Modo Claro en Carrito y Perfil.

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -16,6 +16,10 @@
     <link href="css/styles.css" rel="stylesheet" />
     <link
       rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css"
+    />
+    <link
+      rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/sweetalert2@10.16.0/dist/sweetalert2.min.css"
     />
 

--- a/my-profile.html
+++ b/my-profile.html
@@ -31,6 +31,10 @@
     </style>
     <link
       rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css"
+    />
+    <link
+      rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/sweetalert2@10.16.0/dist/sweetalert2.min.css"
     />
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10.16.0/dist/sweetalert2.all.min.js"></script>


### PR DESCRIPTION
Fixes #13
Hacer visible el icono del modo de color.
Se hizo visible importando los iconos de bootstrap.